### PR TITLE
fix: Modifier le return de la méthode pour "a / b" au lieu de "a // b"

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -48,4 +48,4 @@ def divide(a,b):
     Returns:
         float: Le quotient.
     """
-    return a // b
+    return a / b

--- a/tests/test.py
+++ b/tests/test.py
@@ -22,7 +22,7 @@ class TestApp(unittest.TestCase):
     def test_division(self):
         """Test division operation"""
         result = calculate("1234567890 / 987654321")
-        self.assertEqual(result, 1234567890//987654321)
+        self.assertEqual(result, 1234567890/987654321)
     
     def test_division_by_zero(self):
         """Test division by zero raises error"""


### PR DESCRIPTION
Modifier le return de la méthode pour "a / b" au lieu de "a // b" afin de véritablement faire une division et non une division entière (qui arrondit au int en dessous). Aussi, j'ai modifié le test pour "1234567890 / 987654321" afin de faire une vrai division. Le test passe correctement